### PR TITLE
Key expansion 128bit

### DIFF
--- a/KeyExpansion128bit.v
+++ b/KeyExpansion128bit.v
@@ -7,7 +7,7 @@ assign keyschedule[0:127]=key;
 genvar i;
 
 generate
-    for(i=4;i<44;i=i+1)begin //generate word by word from (4) to (43)
+    for(i=4;i<44;i=i+1)begin : GenerateBlock //generate word by word from (4) to (43)
         if(i%4==0)begin
         assign keyschedule[(i * 32) +: 32]=Rotate(subword(keyschedule[(i - 1)* 32 +: 32]))^ keyschedule[( i - 4) * 32 +: 32] ^Rcon(i/4);
         end


### PR DESCRIPTION
The keyExpansion alone synthesizes, but doesn't completely compile in quartus due to 1408 output pins while the FPGA has 458, but it Should work when we synthesize full code : )